### PR TITLE
Fix Marble User Guide typo on HB bank assignments and Makefile improvments

### DIFF
--- a/docs/marble_test_guide/Makefile
+++ b/docs/marble_test_guide/Makefile
@@ -1,7 +1,14 @@
-all: Marble_Test_Guide.pdf
+TEXFILE = Marble_Test_Guide.tex
+
+all: $(TEXFILE:.tex=.pdf)
 
 %.pdf: %.tex
 	pdflatex -interaction nonstopmode -halt-on-error -file-line-error $<
 
 clean:
-	rm *.pdf
+	@rm -f \
+	$(TEXFILE:.tex=.aux) \
+	$(TEXFILE:.tex=.log) \
+	$(TEXFILE:.tex=.out) \
+	$(TEXFILE:.tex=.toc) \
+	$(TEXFILE:.tex=.pdf)

--- a/docs/marble_test_guide/Makefile
+++ b/docs/marble_test_guide/Makefile
@@ -4,6 +4,8 @@ all: $(TEXFILE:.tex=.pdf)
 
 %.pdf: %.tex
 	pdflatex -interaction nonstopmode -halt-on-error -file-line-error $<
+# Run twice to get references right
+	pdflatex -interaction nonstopmode -halt-on-error -file-line-error $<
 
 clean:
 	@rm -f \

--- a/docs/marble_user_guide/Makefile
+++ b/docs/marble_user_guide/Makefile
@@ -1,4 +1,4 @@
-all: Marble_Manual.pdf
+all: Marble_User_Guide.pdf
 
 %.pdf: %.tex
 	pdflatex -interaction nonstopmode -halt-on-error -file-line-error $<

--- a/docs/marble_user_guide/Makefile
+++ b/docs/marble_user_guide/Makefile
@@ -1,7 +1,14 @@
-all: Marble_User_Guide.pdf
+TEXFILE = Marble_User_Guide.tex
+
+all: $(TEXFILE:.tex=.pdf)
 
 %.pdf: %.tex
 	pdflatex -interaction nonstopmode -halt-on-error -file-line-error $<
 
 clean:
-	rm *.pdf
+	@rm -f \
+	$(TEXFILE:.tex=.aux) \
+	$(TEXFILE:.tex=.log) \
+	$(TEXFILE:.tex=.out) \
+	$(TEXFILE:.tex=.toc) \
+	$(TEXFILE:.tex=.pdf)

--- a/docs/marble_user_guide/Makefile
+++ b/docs/marble_user_guide/Makefile
@@ -4,6 +4,8 @@ all: $(TEXFILE:.tex=.pdf)
 
 %.pdf: %.tex
 	pdflatex -interaction nonstopmode -halt-on-error -file-line-error $<
+# Run twice to get references right
+	pdflatex -interaction nonstopmode -halt-on-error -file-line-error $<
 
 clean:
 	@rm -f \

--- a/docs/marble_user_guide/Marble_User_Guide.tex
+++ b/docs/marble_user_guide/Marble_User_Guide.tex
@@ -497,7 +497,7 @@ The connection of both FMC connectors is shown below:
     \begin{enumerate}
         \item LA00...LA33 - connected to FPGA banks 15 and 16.
         \item HA00...HA23 - \textit{not connected}.
-        \item HB00...HA21 - \textit{not connected}.
+        \item HB00...HB21 - \textit{not connected}.
         \item CLK[0..1]\_M2C - connected to FPGA bank 15.
         \item GBTCLK[0..1]\_M2C - connected to CLK MUX IN4 and IN5.
         \item DP[0]\_M2C - connected to high speed MUX.
@@ -509,7 +509,7 @@ The connection of both FMC connectors is shown below:
     \begin{enumerate}
         \item LA00...LA33 - connected to FPGA banks 12 and 14.
         \item HA00...HA23 - connected to FPGA bank 13.
-        \item HB00...HA21 - \textit{not connected}.
+        \item HB00...HB21 - \textit{not connected}.
         \item CLK[0..1]\_M2C - connected to FPGA banks 12 and 14.
         \item GBTCLK[0..1]\_M2C - connected to CLK MUX IN6 and IN7.
         \item DP[0..3]\_M2C - connected to high speed MUX.


### PR DESCRIPTION
This MR fixes 2 things:

- Typo on HB bank assignments to FPGA on Marble User Guide
- Makefile improvements to generating pdfs