### PR TITLE
docs/marble_user_guide: fix GTH to GTX mentions

### DIFF
--- a/docs/marble_user_guide/Marble_User_Guide.tex
+++ b/docs/marble_user_guide/Marble_User_Guide.tex
@@ -265,7 +265,7 @@ https://github.com/BerkeleyLab/bedrock
 \end{leftbar}
 See its projects/test\_marble\_family directory.
 
-\section{GTH Routing}
+\section{GTX Routing}
 Gigabit transceivers routing can be configured by the microcontroller. Transceivers from Bank 116 are permanently connected to module QSFP1. Transceivers from Bank 115 can be routed in 3 ways:
 \begin{enumerate}
     \item 4 transceivers connected to QSFP2
@@ -287,7 +287,7 @@ Transceiver routing configuration can be set by the microcontroller. Three signa
  & 0    & 1    & 1    & FCM2-DP0   & FMC2-DP1   & FMC1-DP0   & FMC2-DP3  \\
  & 1    & X    & X    & QSFP2:3/10 & QSFP2:1/12 & QSFP2:2/11 & QSFP2:4/9 \\ \bottomrule
 \end{tabular}
-\caption{GTH transceivers routing table}\label{table}
+\caption{GTX transceivers routing table}\label{table}
 \end{table}
 
 \begin{figure}[H]


### PR DESCRIPTION
The Kintex-7 transceiver type is GTX, not GTH.